### PR TITLE
Update label filter styles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "kubernetes-label-selector",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Provides a LabelSelector object that understand kubernetes labels and label selector syntax, and works directly with JSON API objects from kubernetes.  Also provides a label filtering widget.",
   "moduleType": [
     "globals"

--- a/labelFilter.css
+++ b/labelFilter.css
@@ -476,12 +476,9 @@
 .filter .navbar-filter-widget .label-filter-add.btn.disabled {
   opacity: .75;
 }
-.filter .active-filters {
-  margin-top: 3px;
-}
 .filter .active-filters .label-filter-active {
-  display: block;
-  margin: 2px 0;
+  display: inline-block;
+  margin: 2px 5px 2px 0;
 }
 .filter .active-filters .label-filter-active .label {
   border-radius: 1px;
@@ -490,10 +487,10 @@
   padding-top: .3em;
 }
 .filter .active-filters .label-filter-active .label-filtering-remove-all i.fa.fa-times {
-  margin-left: 3px;
+  margin-left: 5px;
 }
 .filter .active-filters .label-filter-active-filters {
-  display: block;
+  display: inline-block;
 }
 .filter .active-filters .label-filter-active-filters .label {
   background: #006e9c;
@@ -517,7 +514,6 @@
 @media (min-width: 992px) {
   .filter .active-filters {
     margin-top: 0;
-    padding-top: 25px;
   }
   .filter .active-filters .label-filter-active-filters :first-child {
     margin-right: 0;

--- a/labelFilter.js
+++ b/labelFilter.js
@@ -107,11 +107,7 @@ angular.module('kubernetesUI')
           )
           .append(
             $('<span>')
-              .text("Clear all filters")
-          )
-          .append(
-            $('<i>')
-              .addClass("fa fa-times")
+              .text("Clear filters")
           )
       ).click(function() {
         $(this).hide();

--- a/styles/labelFilter.less
+++ b/styles/labelFilter.less
@@ -164,10 +164,9 @@
   }
 
   .active-filters {
-    margin-top: 3px;
     .label-filter-active {
-      display: block;
-      margin: 2px 0;
+      display: inline-block;
+      margin: 2px 5px 2px 0;
       .label {
         border-radius: 1px;
         display: inline-block;
@@ -175,11 +174,11 @@
         padding-top: .3em;
       }
       .label-filtering-remove-all i.fa.fa-times {
-        margin-left: 3px;
+        margin-left: 5px;
       }
     }
     .label-filter-active-filters {
-      display: block;
+      display: inline-block;
       .label {
         background: @selectize-active-label-bg;
         display: inline-block;
@@ -210,7 +209,6 @@
   .filter {
     .active-filters {
       margin-top: 0;
-      padding-top: 25px;
       .label-filter-active-filters {
         :first-child {
           margin-right: 0;


### PR DESCRIPTION
- Handle extremely long filter values by setting max-width and
  overflow-x styles.
- Shorten "Clear all filters" to "Clear all"
- Show Clear all button inline with filter values to save space
- Don't adjust active filter top margin based on browser size as this
  causes set filters to jump as you resize the browser.

![label_selector_and_filter_example](https://cloud.githubusercontent.com/assets/1167259/7594575/a1ce5146-f8af-11e4-94e5-2bc8d2949d83.png)
