### PR TITLE
Fix bug from 1.0.0 release where clear filter button wasn't re-rendered once filter had been cleared once

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "kubernetes-label-selector",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides a LabelSelector object that understand kubernetes labels and label selector syntax, and works directly with JSON API objects from kubernetes.  Also provides a label filtering widget.",
   "moduleType": [
     "globals"

--- a/labelFilter.js
+++ b/labelFilter.js
@@ -145,7 +145,9 @@ angular.module('kubernetesUI')
           )
       ).click(function() {
         $(this).hide();
-        self._labelFilterActiveFiltersElement.empty();
+        self._labelFilterActiveFiltersElement
+          .find('.label-filter-active-filter')
+          .remove();
         self._clearActiveFilters();
       });
 


### PR DESCRIPTION
- because clear filters button is now withing .label-filter-active-filters it was being deleted after first clear
- instead of emptying everything inside label-filter-active-filters it now looks for label with label-filter-active-filter and removes
